### PR TITLE
fix defer action and add contextError check

### DIFF
--- a/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
@@ -1,0 +1,283 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 64
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 62,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "example",
+          "text": "if (true) {\n    foo()\n}"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 134
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 132,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo2",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "example",
+          "text": "{\n    foo()\n}"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 219
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 218,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "moo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "example",
+          "text": "  x y\n  12345\n     b"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 313
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 312,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "boo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "func"
+        },
+        {
+          "name": "example",
+          "text": "  x y\n  12345\n     b"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 426
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 424,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "goo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "func"
+        },
+        {
+          "name": "example",
+          "text": "x y\n12345\n   b"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
+++ b/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
@@ -1,0 +1,49 @@
+/// <reference path='fourslash.ts' />
+
+/////**
+//// * @example
+//// * if (true) {
+//// *     foo()
+//// * }
+//// */
+////function fo/*1*/o() {
+////    return '2';
+////}
+/////**
+//// @example
+//// {
+////     foo()
+//// }
+//// */
+////function fo/*2*/o2() {
+////    return '2';
+////}
+/////**
+//// * @example
+//// *   x y
+//// *   12345
+//// *      b
+//// */
+////function m/*3*/oo() {
+////    return '2';
+////}
+/////**
+//// * @func
+//// * @example
+//// *   x y
+//// *   12345
+//// *      b
+//// */
+////function b/*4*/oo() {
+////    return '2';
+////}
+/////**
+//// * @func
+//// * @example    x y
+//// *             12345
+//// *                b
+//// */
+////function go/*5*/o() {
+////    return '2';
+////}
+verify.baselineQuickInfo();


### PR DESCRIPTION
* First draft

Solves the initial problem but breaks commentCommentParsing. I also
found a couple more interesting cases.

* Add more tests and fix their bugs

* Another test case

* Some cleanup

I may try do a little more; `margin += tag.end - tag.pos` bothers me a
bit.

* More cleanup

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

