### PR TITLE
Remove useBridgedNSErro

### DIFF
--- a/tests/baselines/reference/binderUninitializedModuleExportsAssignment.symbols
+++ b/tests/baselines/reference/binderUninitializedModuleExportsAssignment.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/salsa/loop.js ===
+var loop1 = loop2;
+>loop1 : Symbol(loop1, Decl(loop.js, 0, 3))
+>loop2 : Symbol(loop2, Decl(loop.js, 1, 3))
+
+var loop2 = loop1;
+>loop2 : Symbol(loop2, Decl(loop.js, 1, 3))
+>loop1 : Symbol(loop1, Decl(loop.js, 0, 3))
+
+module.exports = loop2;
+>module.exports : Symbol("tests/cases/conformance/salsa/loop", Decl(loop.js, 0, 0))
+>module : Symbol(export=, Decl(loop.js, 1, 18))
+>exports : Symbol(export=, Decl(loop.js, 1, 18))
+>loop2 : Symbol(loop2, Decl(loop.js, 1, 3))
+

--- a/tests/baselines/reference/binderUninitializedModuleExportsAssignment.types
+++ b/tests/baselines/reference/binderUninitializedModuleExportsAssignment.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/salsa/loop.js ===
+var loop1 = loop2;
+>loop1 : any
+>loop2 : any
+
+var loop2 = loop1;
+>loop2 : any
+>loop1 : any
+
+module.exports = loop2;
+>module.exports = loop2 : any
+>module.exports : any
+>module : { "tests/cases/conformance/salsa/loop": any; }
+>exports : any
+>loop2 : any
+

--- a/tests/cases/conformance/salsa/binderUninitializedModuleExportsAssignment.ts
+++ b/tests/cases/conformance/salsa/binderUninitializedModuleExportsAssignment.ts
@@ -1,0 +1,8 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: loop.js
+var loop1 = loop2;
+var loop2 = loop1;
+
+module.exports = loop2;


### PR DESCRIPTION
* Fix infinite loop: module.exports alias detection

Previously, module.exports alias detection in the binder could enter an
infinite recursion. Now it does not.

Notably, there are *two* safeguards: a counter limiter that I set at
100, and an already-seen set. I actually prefer the counter limiter code
because it's foolproof and uses less memory. But it takes 100
iterations to escape from loops.

* fix space lint

* Remove already-seen map

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
